### PR TITLE
Feature: Azure CLI Client

### DIFF
--- a/src/AzureCliClient.php
+++ b/src/AzureCliClient.php
@@ -1,0 +1,39 @@
+<?php
+
+
+namespace AzKeyVault;
+
+use Spatie\Url\Url;
+
+class AzureCliClient extends Client {
+    /** @var void */
+    protected $az_path;
+
+    /**
+     * Client constructor
+     */
+    public function __construct() {
+        $this->az_path = exec('which az');
+        if ($this->az_path === false) {
+            $this->az_path = '/usr/bin/az';
+        }
+
+        $this->client = new \GuzzleHttp\Client();
+
+        $this->accessToken = $this->getAccessToken();
+    }
+
+    /**
+     * Get access token using managed identity
+     * @return string
+     */
+    protected function getAccessToken() {
+        // Get Access Token using Azure CLI
+        $resource = 'https://vault.azure.net';
+        $cmd = "$this->az_path account get-access-token --resource=$resource";
+        $last_line = exec($cmd, $output_arr, $error_code);
+        $output = implode("", $output_arr);
+
+        return 'Bearer ' . json_decode($output)->accessToken;
+    }
+}


### PR DESCRIPTION
This will allow us to connect locally and access to AZ Keyvault by using the Azure CLI account.

You need to install azure cli and set the client for now when initializing the Secret, like this:

> $secret = new AzKeyVault\Secret(getenv("KEY_VAULT_URI"), getenv("MANAGED_IDENTITY_CLIENT_ID"), new AzKeyVault\AzureCliClient());

This has been tested just on MacOS.